### PR TITLE
Change from /run to /var

### DIFF
--- a/templates/cloud-config.yaml
+++ b/templates/cloud-config.yaml
@@ -2,7 +2,7 @@
 
 write_files:
   %{~ for f in files ~}
-  - path: /run/app/${f.filename}
+  - path: /var/app/${f.filename}
     permissions: %{ if substr(f.filename, -2, 2) == "sh"}0755%{else}0644%{endif}
     content: ${f.content}
     encoding: b64
@@ -18,13 +18,13 @@ write_files:
 
       [Service]
       Type=simple
-      WorkingDirectory=/run/app
-      Environment=HOME=/run/app TMP=/run/app/.tmp
+      WorkingDirectory=/var/app
+      Environment=HOME=/var/app TMP=/var/app/.tmp
       PassEnvironment=HOME TMP
-      ExecStartPre=-/run/app/.bin/docker-compose -f ${c.filename} rm -f
-      ExecStart=/run/app/.bin/docker-compose -f ${c.filename} up
-      ExecStop=/run/app/.bin/docker-compose -f ${c.filename} stop -t 15
-      ExecStopPost=-/run/app/.bin/docker-compose -f ${c.filename} rm -f
+      ExecStartPre=-/var/app/.bin/docker-compose -f ${c.filename} rm -f
+      ExecStart=/var/app/.bin/docker-compose -f ${c.filename} up
+      ExecStop=/var/app/.bin/docker-compose -f ${c.filename} stop -t 15
+      ExecStopPost=-/var/app/.bin/docker-compose -f ${c.filename} rm -f
 
       [Install]
       WantedBy=multi-user.target
@@ -38,10 +38,10 @@ write_files:
 
       [Service]
       Type=oneshot
-      WorkingDirectory=/run/app
-      Environment=HOME=/run/app TMP=/run/app/.tmp
+      WorkingDirectory=/var/app
+      Environment=HOME=/var/app TMP=/var/app/.tmp
       PassEnvironment=HOME TMP
-      ExecStartPre=-/run/app/.bin/docker-compose pull --ignore-pull-failures
+      ExecStartPre=-/var/app/.bin/docker-compose pull --ignore-pull-failures
       ExecStart=/usr/bin/systemctl restart app.service
 
       [Install]
@@ -55,22 +55,22 @@ write_files:
       After=app.service
 
       [Path]
-      PathChanged=/run/app/.env
+      PathChanged=/var/app/.env
 
       [Install]
       WantedBy=multi-user.target
 
 runcmd:
   - set -x
-  - mkdir -p /run/app/.bin
-  - mkdir -p /run/app/.tmp
+  - mkdir -p /var/app/.bin
+  - mkdir -p /var/app/.tmp
   - "[ $(docker network list -q --filter=name=web) ] || docker network create web"
   - |
-    if [ ! -f /run/app/.bin/docker-compose ]; then
+    if [ ! -f /var/app/.bin/docker-compose ]; then
       curl --connect-timeout 20 --retry 3 --retry-delay 0 --retry-max-time 90 \
         -LJ "https://github.com/docker/compose/releases/download/1.26.1/docker-compose-$(uname -s)-$(uname -m)" \
-        -o /run/app/.bin/docker-compose
-      chmod +x /run/app/.bin/docker-compose
+        -o /var/app/.bin/docker-compose
+      chmod +x /var/app/.bin/docker-compose
     fi
   - systemctl daemon-reload
   - systemctl enable --now app app-monitor.path


### PR DESCRIPTION
Debian and Ubuntu are setting `noexec` flag on `/run` mount point by default. This means that this module is not able to use executable files in `/run/app` (docker-compose and temp directory for docker-compose`).

In this PR I'm changing `/run` to more common `/var` directory. I would also prefer moving docker-compose file from `/run/app/.bin` to something like `/usr/local/bin` but it can be done separately. 

Close #6 