### PR TITLE
Refactor working directory and usage of docker-compose

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,8 @@ locals {
     CONTAINER_PORT             = lookup(var.container, "port", null)
     DOCKER_NETWORK             = "web"
     DOCKER_LOG_DRIVER          = null
+    COMPOSE_DOCKER_IMAGE       = var.docker_compose_image
+    COMPOSE_DOCKER_TAG         = var.docker_compose_tag
     TRAEFIK_ENABLED            = null
     TRAEFIK_IMAGE_TAG          = null
     TRAEFIK_LOG_LEVEL          = null

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,7 @@ output "cloud_config" {
 }
 
 output "environment_variables" {
-  value = local.dot_env_data
+  value = local.environment
 }
 
 output "included_files" {

--- a/templates/cloud-config.yaml
+++ b/templates/cloud-config.yaml
@@ -17,14 +17,22 @@ write_files:
       After=docker.service
 
       [Service]
-      Type=simple
+      Type=oneshot
+      RemainAfterExit=yes
       WorkingDirectory=/var/app
-      Environment=HOME=/var/app TMP=/var/app/.tmp
-      PassEnvironment=HOME TMP
-      ExecStartPre=-/var/app/.bin/docker-compose -f ${c.filename} rm -f
-      ExecStart=/var/app/.bin/docker-compose -f ${c.filename} up
-      ExecStop=/var/app/.bin/docker-compose -f ${c.filename} stop -t 15
-      ExecStopPost=-/var/app/.bin/docker-compose -f ${c.filename} rm -f
+      EnvironmentFile=/var/app/.env
+      ExecStartPre=-/usr/bin/docker run --rm \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        -v "/var/app:/var/app" -w="/var/app" \
+        "$${COMPOSE_DOCKER_IMAGE}:$${COMPOSE_DOCKER_TAG}" -f ${c.filename} rm
+      ExecStart=/usr/bin/docker run --rm \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        -v "/var/app:/var/app" -w="/var/app" \
+        "$${COMPOSE_DOCKER_IMAGE}:$${COMPOSE_DOCKER_TAG}" -f ${c.filename} up -d
+      ExecStop=/usr/bin/docker run --rm \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        -v "/var/app:/var/app" -w="/var/app" \
+        "$${COMPOSE_DOCKER_IMAGE}:$${COMPOSE_DOCKER_TAG}" -f ${c.filename} stop -t 15
 
       [Install]
       WantedBy=multi-user.target
@@ -39,9 +47,11 @@ write_files:
       [Service]
       Type=oneshot
       WorkingDirectory=/var/app
-      Environment=HOME=/var/app TMP=/var/app/.tmp
-      PassEnvironment=HOME TMP
-      ExecStartPre=-/var/app/.bin/docker-compose pull --ignore-pull-failures
+      EnvironmentFile=/var/app/.env
+      ExecStartPre=-/usr/bin/docker run --rm \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        -v "/var/app:/var/app" -w="/var/app" \
+        "$${COMPOSE_DOCKER_IMAGE}:$${COMPOSE_DOCKER_TAG}" pull --ignore-pull-failures
       ExecStart=/usr/bin/systemctl restart app.service
 
       [Install]
@@ -61,16 +71,11 @@ write_files:
       WantedBy=multi-user.target
 
 runcmd:
-  - set -x
-  - mkdir -p /var/app/.bin
-  - mkdir -p /var/app/.tmp
+  # Install Docker if required. Note: This installation method is not
+  # recommended for production deployments
+  # https://github.com/docker/docker-install
+  - which docker > /dev/null 2>&1 || curl -fsSL https://get.docker.com | sh
+  # Create network used by Traefik to identify running containers
   - "[ $(docker network list -q --filter=name=web) ] || docker network create web"
-  - |
-    if [ ! -f /var/app/.bin/docker-compose ]; then
-      curl --connect-timeout 20 --retry 3 --retry-delay 0 --retry-max-time 90 \
-        -LJ "https://github.com/docker/compose/releases/download/1.26.1/docker-compose-$(uname -s)-$(uname -m)" \
-        -o /var/app/.bin/docker-compose
-      chmod +x /var/app/.bin/docker-compose
-    fi
-  - systemctl daemon-reload
-  - systemctl enable --now app app-monitor.path
+  # Enable systemd services responsible for managing Docker Compose services
+  - systemctl daemon-reload && systemctl enable --now app app-monitor.path

--- a/templates/cloud-config.yaml
+++ b/templates/cloud-config.yaml
@@ -2,7 +2,7 @@
 
 write_files:
   %{~ for f in files ~}
-  - path: /run/app/${f.filename}
+  - path: /var/app/${f.filename}
     permissions: %{ if substr(f.filename, -2, 2) == "sh"}0755%{else}0644%{endif}
     content: ${f.content}
     encoding: b64
@@ -18,13 +18,13 @@ write_files:
 
       [Service]
       Type=simple
-      WorkingDirectory=/run/app
-      Environment=HOME=/run/app TMP=/run/app/.tmp
+      WorkingDirectory=/var/app
+      Environment=HOME=/var/app TMP=/var/app/.tmp
       PassEnvironment=HOME TMP
-      ExecStartPre=-/run/app/.bin/docker-compose -f ${c.filename} rm -f
-      ExecStart=/run/app/.bin/docker-compose -f ${c.filename} up
-      ExecStop=/run/app/.bin/docker-compose -f ${c.filename} stop -t 15
-      ExecStopPost=-/run/app/.bin/docker-compose -f ${c.filename} rm -f
+      ExecStartPre=-/var/app/.bin/docker-compose -f ${c.filename} rm -f
+      ExecStart=/var/app/.bin/docker-compose -f ${c.filename} up
+      ExecStop=/var/app/.bin/docker-compose -f ${c.filename} stop -t 15
+      ExecStopPost=-/var/app/.bin/docker-compose -f ${c.filename} rm -f
 
       [Install]
       WantedBy=multi-user.target
@@ -38,10 +38,10 @@ write_files:
 
       [Service]
       Type=oneshot
-      WorkingDirectory=/run/app
-      Environment=HOME=/run/app TMP=/run/app/.tmp
+      WorkingDirectory=/var/app
+      Environment=HOME=/var/app TMP=/var/app/.tmp
       PassEnvironment=HOME TMP
-      ExecStartPre=-/run/app/.bin/docker-compose pull --ignore-pull-failures
+      ExecStartPre=-/var/app/.bin/docker-compose pull --ignore-pull-failures
       ExecStart=/usr/bin/systemctl restart app.service
 
       [Install]
@@ -55,22 +55,22 @@ write_files:
       After=app.service
 
       [Path]
-      PathChanged=/run/app/.env
+      PathChanged=/var/app/.env
 
       [Install]
       WantedBy=multi-user.target
 
 runcmd:
   - set -x
-  - mkdir -p /run/app/.bin
-  - mkdir -p /run/app/.tmp
+  - mkdir -p /var/app/.bin
+  - mkdir -p /var/app/.tmp
   - "[ $(docker network list -q --filter=name=web) ] || docker network create web"
   - |
-    if [ ! -f /run/app/.bin/docker-compose ]; then
+    if [ ! -f /var/app/.bin/docker-compose ]; then
       curl --connect-timeout 20 --retry 3 --retry-delay 0 --retry-max-time 90 \
         -LJ "https://github.com/docker/compose/releases/download/1.26.1/docker-compose-$(uname -s)-$(uname -m)" \
-        -o /run/app/.bin/docker-compose
-      chmod +x /run/app/.bin/docker-compose
+        -o /var/app/.bin/docker-compose
+      chmod +x /var/app/.bin/docker-compose
     fi
   - systemctl daemon-reload
   - systemctl enable --now app app-monitor.path

--- a/variables.tf
+++ b/variables.tf
@@ -45,3 +45,15 @@ variable "enable_webhook" {
   type        = bool
   default     = false
 }
+
+variable "docker_compose_image" {
+  description = "Docker image used to run Docker Compose commands. (default: docker/compose)"
+  type        = string
+  default     = "docker/compose"
+}
+
+variable "docker_compose_tag" {
+  description = "Tagged version of Docker Compose to use. (default: latest)"
+  type        = string
+  default     = "latest"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -17,31 +17,31 @@ variable "letsencrypt_staging" {
 }
 
 variable "files" {
-  description = "A list of files to upload to the server. Content must be base64 encoded. Files are available under the `/run/app/` directory."
+  description = "User files to be copied to the application's working directory (`/var/app`). The file's content must be provided to Terraform as a base64 encoded string."
   type        = list(object({ filename : string, content : string }))
   default     = []
 }
 
 variable "env" {
-  description = "A list environment variables provided as key/value pairs. These can be used to interpolate values within Docker Compsoe files."
+  description = "List of environment variables (KEY=VAL) to be made available within the application container and also Docker Compose (useful for overriding configuration options)."
   type        = map(string)
   default     = {}
 }
 
 variable "container" {
-  description = "The container definition used to deploy a Docker image to the server. Follows the same schema as a Docker Compose service."
+  description = "Object containing the definition of the container to deploy. The key and values from this object are interpolated directly into the Docker Compose file used to run your application, refer to the Docker Compose documentation for more information."
   type        = any
   default     = {}
 }
 
 variable "cloudinit_part" {
-  description = "Supplementary cloud-init config used to customise the instance."
+  description = "Additional cloud-init configuration used to setup and/or customise the instance beyond the defaults provided by this module."
   type        = list(object({ content_type : string, content : string }))
   default     = []
 }
 
 variable "enable_webhook" {
-  description = "Flag whether to enable the webhook endpoint on the server, allowing updates to be made independent of Terraform."
+  description = "Enabling this feature will expose an endpoint (`/hooks/update-env`) on the server allowing updates to be made to the application's environment variables via a PATCH request. The webhook service will trigger Docker Compose to pull the latest version of the application's container image and restart the service."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
This change required a bit more of a refactor than I'd initially given it credit for.

The trouble comes from supporting Google's Container-Optimized OS and its [mostly read-only filesystem](https://cloud.google.com/container-optimized-os/docs/concepts/disks-and-filesystem). I'd originally opted to install Docker Compose under `/run/app` as this seemed to be one of the few locations that could be written to and also executable.

In hindsight, a much better / portable solution is to not install Docker Compose at all and instead run it from a container on Docker. So that's what I've updated in this PR, as well as incorporating @boscard's changes that updates the working directory to `/var/app` (it no longer matters that this path is non-executable on COS!).

This leaves the only real dependency being `docker` and cloud-init. I've also added a step to the cloud-init config that checks and installs Docker if necessary (using this script: https://github.com/docker/docker-install). This should help with #6 and also opens up the possibility to use other OS images that may not come with Docker pre-installed. 

Thanks @boscard for the initial PR and @crisp2u for your patience!
