### PR TITLE
Allow outgoing traffic from droplet (to pull images)

### DIFF
--- a/examples/digitalocean-docker-image-simple/main.tf
+++ b/examples/digitalocean-docker-image-simple/main.tf
@@ -54,4 +54,10 @@ resource "digitalocean_firewall" "app" {
     port_range       = "443"
     source_addresses = ["0.0.0.0/0", "::/0"]
   }
+
+  outbound_rule {
+    protocol         = "tcp"
+    port_range       = "all"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
 }


### PR DESCRIPTION
While trying the digital ocean example, I realized I was not able to pull any image (including `docker/compose`) without allowing outgoing traffic.

This fixes the example (although the firewall is kind of out of scope for this example, I kept it).

Cool project! I'm using it as a boostrapper for several cloud projects.