### PR TITLE
Assign floating IP to domain instead of droplet ip

### DIFF
--- a/examples/digitalocean-docker-image-simple/main.tf
+++ b/examples/digitalocean-docker-image-simple/main.tf
@@ -33,7 +33,7 @@ resource "digitalocean_floating_ip_assignment" "app" {
 
 resource "digitalocean_domain" "default" {
   name       = "app.${var.domain}"
-  ip_address = digitalocean_droplet.app.ipv4_address
+  ip_address = digitalocean_floating_ip.app.ip_address
 }
 
 /* Firewall ----------------------------------------------------------------- */


### PR DESCRIPTION
In the DigitalOcean example a floating IP was created but not used. I assume the original intent was to assign that to the domain (to allow for several apply/destroy cycles without worrying about the DNS cache).